### PR TITLE
Correctly set and escape attribute values. Fixes #1.

### DIFF
--- a/facebook-opengraph-tags/facebook-opengraph-tags.php
+++ b/facebook-opengraph-tags/facebook-opengraph-tags.php
@@ -13,10 +13,10 @@
 add_action('wp_head', 'opengraphsingle');
 function opengraphsingle(){
 	if ( is_single() ) {
-		echo '<meta property="og:site_name" content="',bloginfo('name'),'"/>';
-		echo '<meta property="og:url" content="',the_permalink(),'"/>';
-		echo '<meta property="og:title" content="',wp_strip_all_tags(the_title('','',false)),'"/>';
-		echo '<meta property="og:description" content="',wp_strip_all_tags(get_the_excerpt()),'"/>';
+		echo '<meta property="og:site_name" content="',esc_attr(bloginfo('name')),'"/>';
+		echo '<meta property="og:url" content="',esc_attr(the_permalink()),'"/>';
+		echo '<meta property="og:title" content="',esc_attr(wp_strip_all_tags(the_title('','',false))),'"/>';
+		echo '<meta property="og:description" content="',esc_attr(wp_strip_all_tags(get_the_excerpt())),'"/>';
 		if(has_post_thumbnail()){
 			$image = wp_get_attachment_image_src( get_post_thumbnail_id(), 'full' );
 			echo '<meta property="og:image" content="',$image[0],'"/>';

--- a/facebook-opengraph-tags/facebook-opengraph-tags.php
+++ b/facebook-opengraph-tags/facebook-opengraph-tags.php
@@ -16,11 +16,7 @@ function opengraphsingle(){
 		echo '<meta property="og:site_name" content="',bloginfo('name'),'"/>';
 		echo '<meta property="og:url" content="',the_permalink(),'"/>';
 		echo '<meta property="og:title" content="',the_title(),'"/>';
-		if( has_excerpt() ){ 
-			echo '<meta property="og:description" content="',get_the_excerpt(),'"/>';
-		} else {
-			echo '<meta property="og:description" content="',get_the_content(),'"/>';
-		}
+		echo '<meta property="og:description" content="',get_the_excerpt(),'"/>';
 		if(has_post_thumbnail()){
 			$image = wp_get_attachment_image_src( get_post_thumbnail_id(), 'full' );
 			echo '<meta property="og:image" content="',$image[0],'"/>';

--- a/facebook-opengraph-tags/facebook-opengraph-tags.php
+++ b/facebook-opengraph-tags/facebook-opengraph-tags.php
@@ -15,8 +15,8 @@ function opengraphsingle(){
 	if ( is_single() ) {
 		echo '<meta property="og:site_name" content="',bloginfo('name'),'"/>';
 		echo '<meta property="og:url" content="',the_permalink(),'"/>';
-		echo '<meta property="og:title" content="',the_title(),'"/>';
-		echo '<meta property="og:description" content="',get_the_excerpt(),'"/>';
+		echo '<meta property="og:title" content="',wp_strip_all_tags(the_title('','',false)),'"/>';
+		echo '<meta property="og:description" content="',wp_strip_all_tags(get_the_excerpt()),'"/>';
 		if(has_post_thumbnail()){
 			$image = wp_get_attachment_image_src( get_post_thumbnail_id(), 'full' );
 			echo '<meta property="og:image" content="',$image[0],'"/>';


### PR DESCRIPTION
This PR will correctly render attribute values by:

- stripping HTML tags (if needed)
- escaping the values

Above that it will also prevent the `og:description` from becoming too long by auto-generating an excerpt.